### PR TITLE
Fix must_quote call convention to avoid memory corruption when excel_tricks is enabled for output.

### DIFF
--- a/src/csv.ml
+++ b/src/csv.ml
@@ -795,7 +795,7 @@ let write_escaped oc field =
       really_output oc (Bytes.unsafe_of_string field) 0 len
     else (
       let field =
-        if n = 0 then Bytes.unsafe_of_string field
+        if n <= 0 then Bytes.unsafe_of_string field
         else (* There are some quotes to escape *)
           let s = Bytes.create (len + n) in
           let j = ref 0 in


### PR DESCRIPTION
The given patch fixes a bug that implied memory corruptions in some cases. The bug is observable on the following code:

Csv.output_all (Csv.to_channel ~excel_tricks:true stdout) [ [ "01234567" ] ]

In fact, it appears when excel_tricks is true and when a field starts with '0', do not contains any occurrence of '\n', '\r' or the separator, and have a length of the form (8 * n - 1). In this case, the function must_quote returns -1, and the buffer s allocated on csv.ml line 800 is too small by 1 to store all the characters. The last Byte.unsafe_set then corrupts the size tag of the string s (when String.length n mod 8 = 7) or looses the last char in the 0-padding of the string (when String.length n mod 8 < 7). This memory corruption implies funny bugs when the string s is used later.

Anyway, many thanks for this very useful and efficient code!

Benoît.
