### PR TITLE
Two minor fixes

### DIFF
--- a/config/pp.ml
+++ b/config/pp.ml
@@ -4,7 +4,7 @@ let ( / ) = Filename.concat
 
 let read_all fname =
   (* Avoid Bytes for backward compatibility. *)
-  let fh = open_in fname in
+  let fh = open_in_bin fname in
   let len = in_channel_length fh in
   let b = Buffer.create len in
   Buffer.add_channel b fh len;

--- a/src/dune
+++ b/src/dune
@@ -9,4 +9,4 @@
 (rule
  (targets csv.ml)
  (deps    csv.pp.ml csv_memory.ml ../config/pp.exe)
- (action (chdir %{workspace_root} (run config/pp.exe))))
+ (action (chdir %{project_root} (run config/pp.exe))))


### PR DESCRIPTION
- Fixes the build on Windows with CRLF checkout
- Allows use of the repo in a Duniverse by using `%{project_root}` instead of `%{workspace_root}`