### PR TITLE
Needs at least Lwt 2.4.7

### DIFF
--- a/csv-lwt.opam
+++ b/csv-lwt.opam
@@ -19,7 +19,7 @@ depends: [
   "dune"
   "base-bytes"
   "base-unix"
-  "lwt"
+  "lwt" {>= "2.4.7"}
 ]
 synopsis: "A pure OCaml library to read and write CSV files, LWT version"
 description: """


### PR DESCRIPTION
The code uses `Lwt_io.read_into` which needs to be `bytes` not `string`. This is the case starting from Lwt 2.4.7.

Correspondent PR for existing releases in opam-repository: https://github.com/ocaml/opam-repository/pull/21345