### PR TITLE
Add csv-eio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ TODO
 data/
 packages
 .~*
+_opam/
+_build/

--- a/csv-eio.opam
+++ b/csv-eio.opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+maintainer: "Christophe Troestler <Christophe.Troestler@umons.ac.be>"
+authors: ["Richard Jones"
+          "Christophe Troestler"
+          "Simon Grondin"]
+tags: ["csv" "database" "science"]
+license: "LGPL-2.1 with OCaml linking exception"
+homepage: "https://github.com/Chris00/ocaml-csv"
+dev-repo: "git+https://github.com/Chris00/ocaml-csv.git"
+bug-reports: "https://github.com/Chris00/ocaml-csv/issues"
+doc: "https://Chris00.github.io/ocaml-csv/doc"
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "5.0.0"}
+  "csv" {= version}
+  "dune"
+  "base-bytes"
+  "base-unix"
+  "eio_main" {>= "0.12"}
+]
+synopsis: "A pure OCaml library to read and write CSV files, EIO version"
+description: """
+This is a pure OCaml library to read and write CSV files, including
+all extensions used by Excel — e.g. quotes, newlines, 8 bit characters
+in fields, \"0 etc. A special representation of rows of CSV files with
+a header is provided. This version can be used with the concurrency library EIO."""

--- a/eio/csv_eio.mli
+++ b/eio/csv_eio.mli
@@ -1,0 +1,131 @@
+(* File: csv_eio.mli
+
+   Copyright (C) 2023-
+
+     Christophe Troestler <Christophe.Troestler@umons.ac.be>
+     WWW: http://math.umons.ac.be/an/software/
+
+   This library is free software; you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License version 2.1 or
+   later as published by the Free Software Foundation, with the special
+   exception on linking described in the file LICENSE.
+
+   This library is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+   LICENSE for more details. *)
+
+(** Lwt interface to the CSV library.
+
+   This module only offers Lwt input/output functions for CSV files.
+   {!Csv} provides additional functions to transform CSV data. *)
+
+type t = Csv.t
+
+
+(** {2 Input} *)
+
+type in_channel
+(** Stateful handle to input CSV files. *)
+
+val of_source : ?separator:char -> ?strip: bool ->
+                 ?has_header: bool -> ?header: string list ->
+                 ?backslash_escape: bool -> ?excel_tricks:bool ->
+                 ?fix:bool ->
+                 _ Eio.Flow.source -> in_channel
+(** See {!Csv.of_in_obj}. *)
+
+val load : ?separator:char -> ?strip: bool ->
+           ?backslash_escape: bool -> ?excel_tricks:bool -> ?fix:bool ->
+           _ Eio.Path.t -> t
+(** See {!Csv.load} *)
+
+val load_in : ?separator:char -> ?strip: bool ->
+              ?backslash_escape: bool -> ?excel_tricks:bool -> ?fix:bool ->
+              _ Eio.Flow.source -> t
+(** See {!Csv.load_in}. *)
+
+val next : in_channel -> string list
+(** See {!Csv.next} *)
+
+val fold_left : f:('a -> string list -> 'a) ->
+                init:'a -> in_channel -> 'a
+(** See {!Csv.fold_left}. *)
+
+val fold_right : f:(string list -> 'a -> 'a) -> in_channel -> 'a -> 'a
+(** See {!Csv.fold_right}. *)
+
+val iter : f:(string list -> unit) -> in_channel -> unit
+(** See {!Csv.inter}. *)
+
+val current_record : in_channel -> string list
+(** See {!Csv.current_record}. *)
+
+
+(** {2 Output} *)
+
+type out_channel
+
+val to_channel : ?separator:char ->
+                 ?backslash_escape: bool -> ?excel_tricks:bool ->
+                 ?quote_all:bool ->
+                 Eio.Buf_write.t -> out_channel
+(** See {!Csv.to_channel}. *)
+
+val output_record : out_channel -> string list -> unit
+(** See {!Csv.output_record}. *)
+
+val output_all : out_channel -> t -> unit
+(** See {!Csv.output_all}. *)
+
+val save : ?separator:char -> ?backslash_escape: bool -> ?excel_tricks:bool ->
+           ?quote_all:bool ->
+           _ Eio.Path.t -> t -> unit
+(** See {!Csv.save}. *)
+
+val print : ?separator:char -> ?backslash_escape: bool -> ?excel_tricks:bool ->
+            ?quote_all:bool ->
+            stdout:_ Eio.Flow.sink -> t -> unit
+(** See {!Csv.print}. *)
+
+
+(** {2 Functions to access rows when a header is present} *)
+
+(** Represent a row with header.  Compatible with {!Csv.Row}. *)
+module Row : module type of Csv.Row
+
+module Rows : sig
+  val header : in_channel -> string list
+  (** The header declared for this channel.  *)
+
+  val set_header : ?replace: bool -> in_channel -> string list -> unit
+  (** See {!Csv.Rows.set_header}. *)
+
+  val next : in_channel -> Row.t
+  (** See {!Csv.Rows.next}. *)
+
+  val fold_left : f:('a -> Row.t -> 'a) ->
+                  init:'a -> in_channel -> 'a
+  (** See {!Csv.fold_left}. *)
+
+  val fold_right : f:(Row.t -> 'a -> 'a) -> in_channel -> 'a -> 'a
+  (** See {!Csv.fold_right}. *)
+
+  val iter : f:(Row.t -> unit) -> in_channel -> unit
+  (** See {!Csv.iter}. *)
+
+  val input_all : in_channel -> Row.t list
+  (** See {!Csv.input_all}. *)
+
+  val load : ?separator:char -> ?strip: bool ->
+             ?has_header: bool -> ?header: string list ->
+             ?backslash_escape: bool -> ?excel_tricks:bool ->
+             ?fix: bool ->
+             _ Eio.Path.t -> Row.t list
+  (** See {!Csv.load}. *)
+
+  val current : in_channel -> Row.t
+  (** See {!Csv.current_record}. *)
+end
+
+;;

--- a/eio/dune
+++ b/eio/dune
@@ -1,0 +1,17 @@
+(library
+ (name        csv_eio)
+ (public_name csv-eio)
+ (modules     Csv_eio Csv_utils)
+ (flags       :standard -safe-string)
+ (libraries   bytes eio_main csv)
+ (synopsis "A pure OCaml library to read and write CSV files (EIO version)."))
+
+(rule
+ (targets csv_eio.ml)
+ (deps    ../src/csv.pp.ml ../src/csv_memory.ml ../config/pp.exe)
+ (action (chdir %{project_root} (run config/pp.exe))))
+
+(rule
+ (targets csv_utils.ml)
+ (deps    ../src/csv_utils.ml)
+ (action  (copy %{deps} %{targets})))

--- a/tests/dune
+++ b/tests/dune
@@ -38,8 +38,19 @@
  (deps    (:p test_lwt.exe) (glob_files *.csv))
  (action  (run %{p})))
 
+(executables
+ (names     test_eio)
+ (modules   test_eio)
+ (libraries csv_eio eio_main))
+
+(alias
+ (name    runtest)
+ (package csv-eio)
+ (deps    (:p test_eio.exe) (glob_files *.csv))
+ (action  (run %{p})))
+
 
 (rule
- (targets test.ml test_lwt.ml)
+ (targets test.ml test_lwt.ml test_eio.ml)
  (deps   test.pp.ml ../config/pp.exe)
  (action (chdir %{project_root} (run config/pp.exe))))


### PR DESCRIPTION
Thanks for the great library!

I have a particular appreciation for venerable and proven libraries that rarely need to change.

This PR adds support for the new [Eio](https://github.com/ocaml-multicore/eio) concurrency library.

Eio is a modern concurrency library. Notably, it leverages OCaml 5's native concurrency support, solves the [colored function problem](http://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/), and uses [io_uring](https://unixism.net/loti/what_is_io_uring.html) -when available- to achieve impressive performance numbers.

As much as possible, I tried to be _respectful_ of the design of the library. My changes are as unintrusive as I could make them.

Compared to Lwt and Std, Eio is:
- non-monadic (similar to Std)
- async, non-blocking (similar to Lwt)
- Eio has the ability to be zero-copy when io_uring is in use
  - To achieve this, its IO buffer type is `Cstruct.t` (a wrapper around `(char, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t`)
  - The OS reads and writes directly into this userspace buffer
  - As such, for `csv-eio` the type of `in_buf` is `Cstruct.t` instead of `Bytes.t`
- Eio handles file closing using Structured Concurrency
  - `csv-eio` does not need `close_in` or `close_out`

Metaprogramming:
- added `IF_LWT_EIO`: true when csv-lwt OR csv-eio
- added `IF_EIO`: true when csv-eio

Tests are passing.

I left a few questions and notes as Github comments. Feel free to click `Resolve conversation` on them.

Please let me know if there's any code changes I can make to help get this merged.

#### Questions
- I'm interested in finishing #37 (applying your requested changes) if this PR is merged. Is there any objection?
- Eio has dependencies on `cstruct` and `bigstringaf`. I also directly reference and call both of these libraries in `csv.pp.ml`. Should I add them to `csv-eio.opam` and/or `eio/dune` or not?